### PR TITLE
Update version to 0.7.0 and class-transformer dep to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ The [class-transformer](https://github.com/pleerock/class-transformer) and [clas
 
 ## Release notes
 
+**0.7.0**
+* updated `class-transformer` dependency to version `^0.2.0`
+
 **0.6.0**
 * updated `class-validator` dependency to version `^0.9.1`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "class-transformer-validator",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -164,9 +164,9 @@
       "dev": true
     },
     "class-transformer": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.1.9.tgz",
-      "integrity": "sha512-KV0IteiRl95OZ9UzbuPj8RhckuHA4JTC+Q+ZbKTYPsmvB0GgPRG7JBEXiVhBq/U050OVRku4N5t0rSMHw8vDWw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.2.0.tgz",
+      "integrity": "sha512-6N/5WkEmLZCKxyC2CAPYQIJt3pDZzDFag7AExpyWRm7CjaS/U62VDRU+Z2AUrQaNpnuiXRlli0so4PJUqGSVZQ==",
       "dev": true
     },
     "class-validator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-transformer-validator",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A simple wrapper around class-transformer and class-validator which provides nice and programmer-friendly API.",
   "license": "MIT",
   "readmeFilename": "README.md",
@@ -47,7 +47,7 @@
     "@types/mocha": "^5.2.5",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "class-transformer": "^0.1.9",
+    "class-transformer": "^0.2.0",
     "class-validator": "^0.9.1",
     "mocha": "^5.2.0",
     "tslint": "^5.11.0",


### PR DESCRIPTION
Closes #15 
Bumped version to `0.7.0`, since theoretically this is a breaking change in `class-transformer`.
Tests still work, I believe they don't use those breaking changes.