### PR TITLE
Allow check for abstract class 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from "class-validator";
 import { plainToClass, ClassTransformOptions } from "class-transformer";
 
-export type ClassType<T> = new (...args: any[]) => T;
+export type ClassType<T> = {prototype: T};
 
 export interface TransformValidationOptions {
   validator?: ValidatorOptions;


### PR DESCRIPTION
Hello, currently abstract class cant pass `transformAndValidate` type check.

When `export declare type ClassType<T> = new (...args: any[]) => T;`, abstract class validate can't pass type check.

```ts
abstract class User {
    @IsString()
    @MinLength(5)
    name: string;
}

let user: User = {
    name: 'hello'
};

transformAndValidate(User, user);
```

Use `export type ClassType<T> = {prototype: T};` to allow check for abstract class, and plain object also cant pass check