### PR TITLE
feat: upgrade deps to use the package in ts4 project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,9 +116,9 @@
       "dev": true
     },
     "@types/validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==",
+      "version": "13.6.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw==",
       "dev": true
     },
     "aggregate-error": {
@@ -322,21 +322,20 @@
       "dev": true
     },
     "class-transformer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
-      "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==",
       "dev": true
     },
     "class-validator": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.12.2.tgz",
-      "integrity": "sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
       "dev": true,
       "requires": {
-        "@types/validator": "13.0.0",
-        "google-libphonenumber": "^3.2.8",
-        "tslib": ">=1.9.0",
-        "validator": "13.0.0"
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
       }
     },
     "clean-stack": {
@@ -780,12 +779,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "google-libphonenumber": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz",
-      "integrity": "sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw==",
-      "dev": true
-    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -1049,6 +1042,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "libphonenumber-js": {
+      "version": "1.9.23",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.23.tgz",
+      "integrity": "sha512-+qWSwPyJWSV9ukb7Iu21WpWEP7irFWR1ojoYykL2itAfXKj9FjsTjS6PPZoPUOZk+1kxliHjwsilqA1TNeOhuQ==",
       "dev": true
     },
     "lines-and-columns": {
@@ -1762,12 +1761,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tslib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-      "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
-      "dev": true
-    },
     "tslint": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
@@ -1889,15 +1882,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "class-transformer": ">=0.2.3",
-    "class-validator": ">=0.12.0"
+    "class-transformer": ">=0.4.0",
+    "class-validator": ">=0.13.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",
@@ -16,15 +16,15 @@
     "@types/mocha": "^8.0.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "class-transformer": "^0.3.1",
-    "class-validator": "^0.12.2",
+    "class-transformer": "^0.4.0",
+    "class-validator": "^0.13.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "mocha": "^8.1.1",
     "prettier": "^2.0.5",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.9.7"
+    "typescript": "^4.3.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
In TypeScript v4 project, `transformAndValidate` cannot transform nested objects.

API changes of TypeScript compiler cause it, I guess.