### PR TITLE
Updates class-validator and class-transformer to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,9 +116,9 @@
       "dev": true
     },
     "@types/validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-+jBxVvXVuggZOrm04NR8z+5+bgoW4VZyLzUO+hmPPW1mVFL/HaitLAkizfv4yg9TbG8lkfHWVMQ11yDqrVVCzA==",
       "dev": true
     },
     "aggregate-error": {
@@ -322,21 +322,19 @@
       "dev": true
     },
     "class-transformer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
-      "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.0.tgz",
+      "integrity": "sha512-ONKKYWNXc1IxBqmTeQZCArFryPG/w4ilHd5Mn4Y/NJlkAlAG4UWUcrnPbfSym0eZBr0pj3i0MdZqyxGHCGlCdQ==",
       "dev": true
     },
     "class-validator": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.12.2.tgz",
-      "integrity": "sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
       "dev": true,
       "requires": {
-        "@types/validator": "13.0.0",
-        "google-libphonenumber": "^3.2.8",
-        "tslib": ">=1.9.0",
-        "validator": "13.0.0"
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
       }
     },
     "clean-stack": {
@@ -780,12 +778,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "google-libphonenumber": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz",
-      "integrity": "sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw==",
-      "dev": true
-    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -1049,6 +1041,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "libphonenumber-js": {
+      "version": "1.9.43",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.43.tgz",
+      "integrity": "sha512-tNB87ZutAiAkl3DE/Bo0Mxqn/XZbNxhPg4v9bYBwQQW4dlhBGqXl1vtmPxeDWbrijzwOA9vRjOOFm5V9SK/W3w==",
       "dev": true
     },
     "lines-and-columns": {
@@ -1762,12 +1760,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tslib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-      "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
-      "dev": true
-    },
     "tslint": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
@@ -1895,9 +1887,9 @@
       "dev": true
     },
     "validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -7,17 +7,18 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "class-transformer": ">=0.2.3",
-    "class-validator": ">=0.12.0"
+    "class-transformer": ">=0.5.0",
+    "class-validator": ">=0.13.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",
     "@types/chai-as-promised": "^7.1.3",
     "@types/mocha": "^8.0.2",
+    "@types/validator": "^13.7.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "class-transformer": "^0.3.1",
-    "class-validator": "^0.12.2",
+    "class-transformer": "^0.5.0",
+    "class-validator": "^0.13.2",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "mocha": "^8.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {
   validateOrReject,
   ValidatorOptions,
 } from "class-validator";
-import { plainToClass, ClassTransformOptions } from "class-transformer";
+import { plainToInstance, ClassTransformOptions } from "class-transformer";
 
 export type ClassType<T> = new (...args: any[]) => T;
 
@@ -78,7 +78,7 @@ export function transformAndValidate<T extends object>(
       );
     }
 
-    const classObject = plainToClass(
+    const classObject = plainToInstance(
       classType,
       object,
       options ? options.transformer : void 0,
@@ -163,7 +163,7 @@ export function transformAndValidateSync<T extends object>(
     );
   }
 
-  const classObject = plainToClass(
+  const classObject = plainToInstance(
     classType,
     object,
     options ? options.transformer : void 0,


### PR DESCRIPTION
This PR updates class-validator and class-transformer to their latest versions, allowing projects that depend on class-transformer-validator, to update to the latest versions of the peer dependencies.

Changes:

- The latest class-validator no longer lists @types/validator as a runtime dependency, that's why it's been added to the list of dependencies here.
- The 0.5.0 version of class-transformer replaces the usage of the word `Class` in methods to `Instance`. Example: `plainToClass` is renamed to `plainToInstance`. 